### PR TITLE
User Profile Info and Expanded Game Details for Game Collection

### DIFF
--- a/src/Components/App/App.css
+++ b/src/Components/App/App.css
@@ -1,12 +1,6 @@
 .App {
   display: flex;
   flex-direction: column;
-  background: linear-gradient(
-    to bottom,
-    rgba(44, 23, 84, 0.9),
-    rgba(42, 21, 83, 0.93),
-    rgba(41, 20, 82, 1)
-  );
   min-height: 100vh;
   max-width: 100vw;
 }

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -21,8 +21,8 @@ import {
 
 
 function App() {
-  const [loggedIn, setLoggedIn] = useState(null);
-  const [selectedUser, setSelectedUser] = useState(null);
+  const [loggedIn, setLoggedIn] = useState(true);
+  const [selectedUser, setSelectedUser] = useState(1);
 
   const { loading, error, data } = useQuery(getUser, { variables: { id: selectedUser }, skip: !selectedUser });
 
@@ -65,7 +65,7 @@ function App() {
             )}
           </Route>
         <Route exact path="/profile">
-          <ProfilePage logoutUser={logoutUser} selectedUser={selectedUser}/>
+          <ProfilePage logoutUser={logoutUser} selectedUser={selectedUser} userData={data.user}/>
         </Route>
         <Route exact path="/new-event">
           <Form logoutUser={logoutUser}/>

--- a/src/Components/Profile/Profile.css
+++ b/src/Components/Profile/Profile.css
@@ -75,22 +75,6 @@
 .games-grid {
   margin-top: 2rem;
   display: grid;
-
+  grid-gap: 3rem;
 }
 
-.game-circle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100px;
-  height: 100px;
-  border: 2px solid white;
-  border-radius: 50%;
-  margin-right: 10px;
-}
-
-.game-circle img {
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
-}

--- a/src/Components/Profile/Profile.js
+++ b/src/Components/Profile/Profile.js
@@ -3,12 +3,22 @@ import Header from '../ReusableComponents/Header/Header';
 import BrowserHeader from '../ReusableComponents/BrowserHeader/BrowserHeader';
 import UserGame from './UserGame/UserGame';
 import { useQuery } from '@apollo/client';
+import { useState } from 'react';
 import { getUserGames } from '../../queries/index';
 import userIcon from '../../assets/usericon.svg';
 import diceicon from '../../assets/diceicon.png';
 
-const ProfilePage = ({logoutUser, selectedUser}) => {
-  const { loading, error, data } = useQuery(getUserGames, { variables: { id: 1 } });
+const ProfilePage = ({logoutUser, selectedUser, userData}) => {
+  const { loading, error, data } = useQuery(getUserGames, { variables: { id: selectedUser } });
+  const [expandedGame, setExpandedGame] = useState(null);
+
+  const handleExpandClick = (gameName) => {
+    if(expandedGame === gameName) {
+      setExpandedGame(null);
+    } else {
+      setExpandedGame(gameName);
+    }
+  };
 
   const mapUserGames = () => {
     if(data?.user?.ownedGames?.length) {
@@ -17,14 +27,10 @@ const ProfilePage = ({logoutUser, selectedUser}) => {
         return (
           <UserGame 
             key={game.id}
-            name={game.name}
-            image={game.imageUrl}
-            maxPlayers={game.maxPlayers}
-            minPlayers={game.minPlayers}
-            minPlaytime={game.minPlaytime}
-            maxPlaytime={game.maxPlaytime}
-            complexity={game.averageStrategyComplexity}
-            rating={game.averageUserRating}
+            {...game}
+            handleExpand={handleExpandClick}
+            expanded={expandedGame === game.name}
+            hidden={expandedGame && expandedGame !== game.name}
           />
         )
       })
@@ -44,15 +50,15 @@ const ProfilePage = ({logoutUser, selectedUser}) => {
               <section className="profile-text">
                 <div className="profile-key-value">
                   <p className="profile-text-key">Name</p>
-                  <p className="profile-text-value">John Doe</p>
+                  <p className="profile-text-value">{userData.username}</p>
                 </div>
                 <div className="profile-key-value">
-                  <p className="profile-text-key">Games Hosted</p>
-                  <p className="profile-text-value">5</p>
+                  <p className="profile-text-key">Games Owned</p>
+                  <p className="profile-text-value">{data.user.ownedGames.length}</p>
                 </div>
                 <div className="profile-key-value">
                   <p className="profile-text-key">Location</p>
-                  <p className="profile-text-value">City, State</p>
+                  <p className="profile-text-value">{userData.city}, {userData.state}</p>
                 </div>
               </section>
             </div>

--- a/src/Components/Profile/UserGame/UserGame.css
+++ b/src/Components/Profile/UserGame/UserGame.css
@@ -7,16 +7,22 @@
   align-items: center;
 }
 
+.user-game-hidden {
+  opacity: 0.2;
+  z-index: -1;
+}
+
 .game-card {
   display: flex;
   flex-direction: column;
   width: 95%;
-  height: 90%;
-  margin-left: 2rem;
+  height: auto;
+  margin: 2rem 0 2rem 3rem;
 }
 
 .game-card-title {
   font-size: 1.5rem;
+  font-family: 'Avenir Next', sans-serif;
   font-weight: 600;
   margin: 0;
 }
@@ -48,4 +54,31 @@
   width: 100%;
   height: 100%;
   position: absolute;
+}
+
+.game-card-header {
+  background: rgb(193, 192, 192);
+}
+
+.game-card-high-level {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.game-key, .game-value {
+  color: rgb(89, 89, 89);
+  font-size: 0.9rem;
+}
+
+.game-value {
+  margin: 0.3rem;
+}
+
+.game-key-value {
+  margin: 0;
+}
+
+.description-text * {
+  font-size: 0.9rem;
+  color: black;
 }

--- a/src/Components/Profile/UserGame/UserGame.js
+++ b/src/Components/Profile/UserGame/UserGame.js
@@ -1,17 +1,66 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Collapse, Button } from '@mui/material';
 import './UserGame.css';
 
-const UserGame = ({name, image, maxPlayers, minPlayers, maxPlaytime, minPlaytime, rating, complexity }) => {
+const UserGame = ({name, imageUrl, maxPlayers, minPlayers, maxPlaytime, minPlaytime, averageUserRating, averageStrategyComplexity, description, handleExpand, expanded, hidden }) => {
+  const handleExpandClick = () => {
+    handleExpand(name);
+  }
+
   return (
-    <section className="user-game">
+    <section className={`user-game ${hidden ? 'user-game-hidden' : ''}`}>
       <div className="card-image">
-        <img src={image} alt={`${name} thumbnail`} />
+        <img src={imageUrl} alt={`${name} thumbnail`} />
       </div>
       <article className="card game-card">
-        <div className="card-header">
+        <div className="card-header game-card-header">
           <h5 className="event-card-title">{name}</h5>
         </div>
-        <div className="game-card-body">
+        <div className="card-body">
+          <Collapse in={!expanded} timeout="auto">
+            <section className="game-card-high-level">
+              <div className="profile-key-value game-key-value">
+                <p className="profile-text-key game-key">Players</p>
+                <p className="profile-text-value game-value">{minPlayers} - {maxPlayers}</p>
+              </div>
+              <div className="profile-key-value game-key-value">
+                <p className="profile-text-key game-key">Estimated Playtime</p>
+                <p className="profile-text-value game-value">{minPlaytime} - {maxPlaytime}</p>
+              </div>
+              <div className="profile-key-value game-key-value">
+                <p className="profile-text-key game-key">Average User Rating</p>
+                <p className="profile-text-value game-value">{averageUserRating.toFixed(2)}</p>
+              </div>
+              <div className="profile-key-value game-key-value">
+                <p className="profile-text-key game-key">Complexity</p>
+                <p className="profile-text-value game-value">{averageStrategyComplexity.toFixed(2)} / 5</p>
+              </div>
+            </section>
+          </Collapse>
+          <Collapse in={expanded} timeout="auto">
+          <section className="game-card-high-level">
+              <div className="profile-key-value game-key-value">
+                <p className="profile-text-key game-key">Players</p>
+                <p className="profile-text-value game-value">{minPlayers} - {maxPlayers}</p>
+              </div>
+              <div className="profile-key-value game-key-value">
+                <p className="profile-text-key game-key">Estimated Playtime</p>
+                <p className="profile-text-value game-value">{minPlaytime} - {maxPlaytime}</p>
+              </div>
+              <div className="profile-key-value game-key-value">
+                <p className="profile-text-key game-key">Average User Rating</p>
+                <p className="profile-text-value game-value">{averageUserRating.toFixed(2)}</p>
+              </div>
+              <div className="profile-key-value game-key-value">
+                <p className="profile-text-key game-key">Complexity</p>
+                <p className="profile-text-value game-value">{averageStrategyComplexity.toFixed(2)} / 5</p>
+              </div>
+            </section>
+            <div dangerouslySetInnerHTML={{ __html: description }} className="description-text"/>
+          </Collapse>
+          <Button onClick={() => handleExpandClick(name)} aria-expanded={expanded} aria-label="show more">
+            {expanded ? 'Show Less' : 'More Info'}
+          </Button>
         </div>
       </article>
     </section>

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,13 @@
 body {
   margin: 0;
+  min-height: 100vh;
+  height: auto;
+  background: linear-gradient(
+    to bottom,
+    rgba(44, 23, 84, 0.9),
+    rgba(42, 21, 83, 0.93),
+    rgba(41, 20, 82, 1)
+  );
   font-family: 'Source Sans Variable', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
# Checklist:

## Type of change:

   - [x] New feature
   - [] Bug Fix
   - [x] Refactor

## Description of Changes:

- Expands on the user profile page to bring in the current user's profile information and to populate their game collection with the information provided by the server, including min/max players, min/max playtime, and the expanded flavor text/game description.

![image](https://github.com/Game-Night-2301/game-night-fe/assets/122237567/39223e37-36a2-4926-be29-87a39709708b)


## Requested feedback: 
    
I think there's still some tweaks that could be made here on presentation, and I think the components and CSS could definitely do with some refactoring, but I'm going to leave this here for the time being and contribute more to the actual working of the site.

## Check the correct boxes:

   - [] This broke nothing
   - [x] This broke some stuff
   - [] This broke everything

I'm seeing that the user profile page tests aren't working due to the URL when I last checked, but also I think I've changed some class tags etc. that might require revisiting the tests anyway. I'll make that a priority.

## Testing Changes:

   - [x] No Tests have been changed
   - [] Some Tests have been changed
   - [] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:
   - [] All Tests are Passing
   - [] My code has no unused/commented out code
   - [x] I have reviewed my code
   - [x] I have commented on my code, particularly in hard-to-understand areas
   - [] I have fully tested my code
   - [x] I have added one or more people as "Reviewers" to review & merge
