### PR TITLE
[NON-MVP] Recommendations Page and User Session Caching

### DIFF
--- a/cypress/e2e/browserpage.cy.js
+++ b/cypress/e2e/browserpage.cy.js
@@ -49,9 +49,9 @@ describe('Browse Page', () => {
         cy.get('.card-link-wrapper').should('have.length', 3);
         cy.get('.card-link-wrapper').first()
           .within(() => {
-            cy.get('.event-card-title').should('have.text', '1 title');
-            cy.get('.event-card-subtitle').should('have.text', '1 city, 1 state (11111)10/31/2022');
-            cy.get('.event-card-description').should('have.text', '1 description');
+            cy.get('.event-card-title').should('have.text', 'Wingspan');
+            cy.get('.event-card-subtitle').should('have.text', 'South Burlington, Vermont (5403)10/20/2023');
+            cy.get('.event-card-description').should('have.text', 'Ha ha, you fool! You fell victim to one of the classic blunders! The most famous of which is never get involved in a land war in Asia, but only slightly less well-known is this: Never go in against a Sicilian when DEATH is on the line.');
             cy.url().should('include', '/browse');
           });
       });

--- a/cypress/e2e/createeventpage.cy.js
+++ b/cypress/e2e/createeventpage.cy.js
@@ -88,6 +88,6 @@ describe('Create Event Page', () => {
     cy.get('.event-time-and-date > :nth-child(2) > .MuiInputBase-root').type("12:05 AM")
     cy.get('.event-time-and-date > :nth-child(3) > .MuiInputBase-root').type("12:10 PM")
     cy.get("#outlined-multiline-static").type("The coolest thing you'll ever play in your entire life.")
-    cy.get(".MuiButton-root").contains('Submit').click()
+    cy.get(".MuiButton-root").contains('Submit').click({force: true})
   })
 });

--- a/cypress/fixtures/allEvents.json
+++ b/cypress/fixtures/allEvents.json
@@ -1,124 +1,124 @@
 {
-    "user": {
+  "user": {
       "__typename": "User",
       "sortedEvents": [
-        {
-          "__typename": "Event",
-          "id": "7",
-          "date": "2022-10-31T20:00:00Z",
-          "address": "1 One street",
-          "city": "1 city",
-          "state": "1 state",
-          "zip": 11111,
-          "title": "1 title",
-          "cancelled": false,
-          "description": "1 description",
-          "host": {
-            "__typename": "User",
-            "id": "16",
-            "username": "user 1"
+          {
+              "__typename": "Event",
+              "id": "7",
+              "date": "2023-10-21T00:00:00Z",
+              "address": "205 Dorset St",
+              "city": "South Burlington",
+              "state": "Vermont",
+              "zip": 5403,
+              "title": "Chipotle",
+              "cancelled": false,
+              "description": "Ha ha, you fool! You fell victim to one of the classic blunders! The most famous of which is never get involved in a land war in Asia, but only slightly less well-known is this: Never go in against a Sicilian when DEATH is on the line.",
+              "hostId": 1,
+              "game": 2,
+              "gameType": "board game",
+              "gameDetails": {
+                  "__typename": "Game",
+                  "name": "Wingspan",
+                  "maxPlayers": 5
+              },
+              "attendees": [
+                  {
+                      "__typename": "User",
+                      "id": "11",
+                      "username": "Herugar Bolger"
+                  },
+                  {
+                      "__typename": "User",
+                      "id": "6",
+                      "username": "Buffo Boffin"
+                  },
+                  {
+                      "__typename": "User",
+                      "id": "4",
+                      "username": "Diamond of Long Cleeve"
+                  }
+              ],
+              "playerCount": 3,
+              "distanceFrom": 33.12975716314347
           },
-          "game": 1,
-          "gameType": "board game",
-          "attendees": [
-            {
-              "__typename": "User",
+          {
+              "__typename": "Event",
               "id": "5",
-              "username": "user 5"
-            },
-            {
-              "__typename": "User",
-              "id": "16",
-              "username": "user 1"
-            },
-            {
-              "__typename": "User",
-              "id": "17",
-              "username": "user 2"
-            },
-            {
-              "__typename": "User",
-              "id": "18",
-              "username": "user 3"
-            }
-          ],
-          "playerCount": 4
-        },
-        {
-          "__typename": "Event",
-          "id": "13",
-          "date": "2022-10-31T20:00:00Z",
-          "address": "1 One street",
-          "city": "1 city",
-          "state": "1 state",
-          "zip": 11111,
-          "title": "1 title",
-          "cancelled": false,
-          "description": "1 description",
-          "host": {
-            "__typename": "User",
-            "id": "31",
-            "username": "user 1"
+              "date": "2023-10-15T00:00:00Z",
+              "address": "580 Shelburne Rd ",
+              "city": "Burlington",
+              "state": "Vermont",
+              "zip": 5401,
+              "title": "Chipotle",
+              "cancelled": false,
+              "description": "Hello. My name is Inigo Montoya. You killed my father. Prepare to die!",
+              "hostId": 5,
+              "game": 2,
+              "gameType": "board game",
+              "gameDetails": {
+                  "__typename": "Game",
+                  "name": "Wingspan",
+                  "maxPlayers": 5
+              },
+              "attendees": [
+                  {
+                      "__typename": "User",
+                      "id": "11",
+                      "username": "Herugar Bolger"
+                  },
+                  {
+                      "__typename": "User",
+                      "id": "8",
+                      "username": "Andwise Roper"
+                  }
+              ],
+              "playerCount": 2,
+              "distanceFrom": 33.9553127826209
           },
-          "game": 1,
-          "gameType": "board game",
-          "attendees": [
-            {
-              "__typename": "User",
-              "id": "31",
-              "username": "user 1"
-            },
-            {
-              "__typename": "User",
-              "id": "32",
-              "username": "user 2"
-            },
-            {
-              "__typename": "User",
-              "id": "33",
-              "username": "user 3"
-            }
-          ],
-          "playerCount": 3
-        },
-        {
-          "__typename": "Event",
-          "id": "5",
-          "date": "2022-10-31T20:00:00Z",
-          "address": "1 One street",
-          "city": "1 city",
-          "state": "1 state",
-          "zip": 11111,
-          "title": "1 title",
-          "cancelled": false,
-          "description": "1 description",
-          "host": {
-            "__typename": "User",
-            "id": "11",
-            "username": "user 1"
-          },
-          "game": 1,
-          "gameType": "board game",
-          "attendees": [
-            {
-              "__typename": "User",
-              "id": "11",
-              "username": "user 1"
-            },
-            {
-              "__typename": "User",
-              "id": "12",
-              "username": "user 2"
-            },
-            {
-              "__typename": "User",
-              "id": "13",
-              "username": "user 3"
-            }
-          ],
-          "playerCount": 3
-        }
+          {
+              "__typename": "Event",
+              "id": "6",
+              "date": "2023-10-04T00:00:00Z",
+              "address": "37 N Main St",
+              "city": "Rutland",
+              "state": "Vermont",
+              "zip": 5701,
+              "title": "Chipotle",
+              "cancelled": false,
+              "description": "Are you coming down into the pit? Westly's got his strength back, I'm starting him on the machine tonight.",
+              "hostId": 6,
+              "game": 2,
+              "gameType": "board game",
+              "gameDetails": {
+                  "__typename": "Game",
+                  "name": "Wingspan",
+                  "maxPlayers": 5
+              },
+              "attendees": [
+                  {
+                      "__typename": "User",
+                      "id": "1",
+                      "username": "Aldor"
+                  },
+                  {
+                      "__typename": "User",
+                      "id": "7",
+                      "username": "Gorbulas Brandybuck"
+                  },
+                  {
+                      "__typename": "User",
+                      "id": "2",
+                      "username": "Malva Headstrong"
+                  },
+                  {
+                      "__typename": "User",
+                      "id": "3",
+                      "username": "Ingold"
+                  }
+              ],
+              "playerCount": 4,
+              "distanceFrom": 49.06431096481071
+          }
       ]
-    }
   }
-  
+}

--- a/cypress/fixtures/eventById.json
+++ b/cypress/fixtures/eventById.json
@@ -1,35 +1,53 @@
 {
-  "event": {
-      "__typename": "Event",
-      "id": "8",
-      "date": "2023-10-08T00:00:00Z",
-      "address": "2320 S Lamar Blvd",
-      "state": "Texas",
-      "city": "Austin",
-      "zip": 78704,
-      "title": "Chipotle",
-      "cancelled": false,
-      "description": "But first things first. To the death!",
-      "hostId": 2,
-      "game": 2,
-      "gameType": "board game",
-      "playerCount": 3,
-      "attendees": [
-          {
-              "__typename": "User",
-              "id": "10",
-              "username": "Arciryas"
-          },
-          {
-              "__typename": "User",
-              "id": "5",
-              "username": "Ecthelion"
-          },
-          {
-              "__typename": "User",
-              "id": "1",
-              "username": "Isengar Took"
-          }
-      ]
-  }
+    "event": {
+        "__typename": "Event",
+        "id": "7",
+        "date": "2023-10-21T00:00:00Z",
+        "address": "205 Dorset St",
+        "state": "Vermont",
+        "city": "South Burlington",
+        "zip": 5403,
+        "lat": 44.464459900548945,
+        "lon": -73.18108287589946,
+        "startTime": "08:00",
+        "endTime": "12:00",
+        "title": "Chipotle",
+        "cancelled": false,
+        "description": "Ha ha, you fool! You fell victim to one of the classic blunders! The most famous of which is never get involved in a land war in Asia, but only slightly less well-known is this: Never go in against a Sicilian when DEATH is on the line.",
+        "hostId": 1,
+        "game": 2,
+        "gameType": "board game",
+        "playerCount": 3,
+        "gameDetails": {
+            "__typename": "Game",
+            "id": "2",
+            "name": "Wingspan",
+            "minPlayers": 1,
+            "maxPlayers": 5,
+            "minPlaytime": 40,
+            "maxPlaytime": 70,
+            "description": "<p><em><strong>Wingspan</strong></em> is a competitive, medium-weight, card-driven, engine-building board game from Stonemaier Games.</p>\r\n<p>You are bird enthusiasts—researchers, bird watchers, ornithologists, and collectors—seeking to discover and attract the best birds to your aviary. Each bird extends a chain of powerful combinations in one of your habitats (actions). These habitats focus on several key aspects of growth:</p>\r\n<ul>\r\n<li>Gain food tokens via custom dice in a birdfeeder dice tower</li>\r\n<li>Lay eggs using egg miniatures in a variety of colors</li>\r\n<li>Draw from hundreds of unique bird cards and play them</li>\r\n</ul>\r\n<p>The winner is the player with the most points after 4 rounds.</p>",
+            "imageUrl": "https://s3-us-west-1.amazonaws.com/5cc.images/games/uploaded/1629325193747.png",
+            "averageUserRating": 4.156873858333332,
+            "averageStrategyComplexity": 2.833333333333333
+        },
+        "host": null,
+        "attendees": [
+            {
+                "__typename": "User",
+                "id": "11",
+                "username": "Herugar Bolger"
+            },
+            {
+                "__typename": "User",
+                "id": "6",
+                "username": "Buffo Boffin"
+            },
+            {
+                "__typename": "User",
+                "id": "4",
+                "username": "Diamond of Long Cleeve"
+            }
+        ]
+    }
 }

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -6083,6 +6083,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apollo3-cache-persist": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/apollo3-cache-persist/-/apollo3-cache-persist-0.14.1.tgz",
+      "integrity": "sha512-p/jNzN/MmSd0TmY7/ts0B3qi0SdQ3w9yNLQdKqB3GGb9xATUlAum2v4hSrTeWd/DZKK2Z7Xg5kFXTH6nNVnKSQ==",
+      "peerDependencies": {
+        "@apollo/client": "^3.2.5"
+      }
+    },
     "node_modules/arch": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "apollo3-cache-persist": "^0.14.1",
         "chalk": "^5.3.0",
         "cors": "^2.8.5",
         "dayjs": "^1.11.9",
@@ -6115,6 +6116,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/apollo3-cache-persist": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/apollo3-cache-persist/-/apollo3-cache-persist-0.14.1.tgz",
+      "integrity": "sha512-p/jNzN/MmSd0TmY7/ts0B3qi0SdQ3w9yNLQdKqB3GGb9xATUlAum2v4hSrTeWd/DZKK2Z7Xg5kFXTH6nNVnKSQ==",
+      "peerDependencies": {
+        "@apollo/client": "^3.2.5"
       }
     },
     "node_modules/arch": {
@@ -25508,6 +25517,12 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "apollo3-cache-persist": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/apollo3-cache-persist/-/apollo3-cache-persist-0.14.1.tgz",
+      "integrity": "sha512-p/jNzN/MmSd0TmY7/ts0B3qi0SdQ3w9yNLQdKqB3GGb9xATUlAum2v4hSrTeWd/DZKK2Z7Xg5kFXTH6nNVnKSQ==",
+      "requires": {}
     },
     "arch": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "apollo3-cache-persist": "^0.14.1",
     "chalk": "^5.3.0",
     "cors": "^2.8.5",
     "dayjs": "^1.11.9",

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { useQuery } from '@apollo/client';
+import { ApolloClient, useQuery, useApolloClient, gql } from '@apollo/client';
 import { BrowserRouter as Router, Switch, Route, Redirect } from 'react-router-dom';
 import WelcomePage from '../WelcomePage/WelcomePage';
 import BrowseEvent from '../BrowseEvent/BrowseEvent';
 import ProfilePage from '../Profile/Profile';
+import RecommendationsPage from '../RecommendationsPage/RecommendationsPage';
 import './App.css';
 import Form from '../EventCreation/Form/Form';
 import Error from '../Error/Error';
@@ -22,24 +23,54 @@ import {
 
 
 function App() {
+  const client = useApolloClient(); // get the client instance
   const [loggedIn, setLoggedIn] = useState(false);
   const [selectedUser, setSelectedUser] = useState(null);
-
   const { loading, error, data } = useQuery(getUser, { variables: { id: selectedUser }, skip: !selectedUser });
 
   useEffect(() => {
-    if (!loading && !error && data) {
+    const cacheData = client.readQuery({
+      query: gql`
+        query GetLoggedInUser {
+          loggedInUser
+        }
+      `,
+    });
+
+    if (cacheData && cacheData.loggedInUser) {
+      setLoggedIn(true);
+      setSelectedUser(cacheData.loggedInUser);
     }
-  }, [loading, error, data, selectedUser]);
+  }, [client]);
 
   const loginUser = (userId) => {
+    client.writeQuery({
+      query: gql`
+        query GetLoggedInUser {
+          loggedInUser
+        }
+      `,
+      data: {
+        loggedInUser: userId,
+      },
+    });
+    setLoggedIn(true); 
     setSelectedUser(userId);
-    setLoggedIn(true);
   };
 
   const logoutUser = () => {
-    setSelectedUser(null);
+    client.writeQuery({
+      query: gql`
+        query GetLoggedInUser {
+        loggedInUser
+        }
+      `,
+      data: {
+        loggedInUser: null,
+      },
+    });
     setLoggedIn(false);
+    setSelectedUser(null);
   };
 
   if (loading) return <PageLoader />;
@@ -62,6 +93,9 @@ function App() {
               </Route>
               <Route exact path="/events/:id">
                 <EventDetails loggedInUser={selectedUser} logoutUser={logoutUser} />
+              </Route>
+              <Route exact path="/recommendations">
+                <RecommendationsPage logoutUser={logoutUser} selectedUser={selectedUser} />
               </Route>
               <Route path="/error">
                 <Error error="Oops! Looks like we rolled a critical error. Time to reshuffle the digital deck!" />

--- a/src/Components/EventDetails/EventDetails.js
+++ b/src/Components/EventDetails/EventDetails.js
@@ -24,6 +24,7 @@ export const EventDetails = ({ loggedInUser, logoutUser }) => {
 
   if (loading) return <PageLoader />; 
   if (error) return <Redirect to="/error" />; 
+  console.log(data)
 
   return (
     <div>

--- a/src/Components/RecommendationsPage/AIRecs/AIRecs.css
+++ b/src/Components/RecommendationsPage/AIRecs/AIRecs.css
@@ -1,0 +1,147 @@
+.ai-recs-section {
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.ai-recs-panel {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  width: 100%;
+  background: rgba(255, 255, 255, 1);
+  opacity: 0.85;
+  border-radius: 8px;
+  padding-right: 1rem;
+  margin: 1rem 0;
+}
+
+.recommend-me-panel {
+  height: 14rem;
+  margin-top: 3rem;
+}
+
+.process-panel {
+  height: 13rem;
+}
+
+.results-panel {
+  height: 15rem;
+}
+
+.panel-collapsed {
+  height: 5rem;
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.ai-recs-panel-collapsed {
+  height: 6rem;
+}
+
+.ai-recs-header-wrapper {
+  display: flex;
+  align-items: center;
+  align-self: center;
+  width: 100%;
+  margin: 3rem 0;
+}
+
+.ai-recs-number-wrapper {
+  height: 100%;
+  min-width: 12%;
+  background: #5d53e6;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.ai-recs-header-number {
+  font-size: 2rem;
+  font-family: 'Avenir Next', sans-serif;
+  font-weight: 600;
+  color: white;
+}
+
+.ai-recs-body {
+  display: grid;
+  grid-template-columns: 4fr 1fr;
+  align-items: center;
+  margin-left: 2rem;
+  width: 100%;
+  height: 100%;
+}
+
+.ai-recs-body-text {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  width: 90%;
+}
+
+.ai-recs-text {
+  font-size: 1.2rem;
+  font-family: 'Avenir Next', sans-serif;
+  font-weight: 400;
+  margin: 0.5rem 0 0 0;
+}
+
+.ai-recs-header {
+  font-size: 2rem;
+  margin: 0;
+  font-weight: 600;
+  color: black;
+}
+
+.collapsed-header {
+  margin-left: 2rem;
+}
+
+.time-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0 1rem 1rem 2rem;
+  width: 10rem;
+}
+
+.time-box {
+  background-color: rgb(93, 83, 230, 0.8);
+  border-radius: 8px;
+  height: 2rem;
+  width: 10rem;
+  padding: 1rem;
+  margin: 0.4rem 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.timer-label {
+  font-size: 0.9rem;
+  text-align: center;
+  font-family: 'Avenir Next', sans-serif;
+  font-weight: 600;
+  margin: 0;
+}
+
+.pulse {
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    background-color: #f0f0f0;
+  }
+  50% {
+    background-color: #d0d0d0;
+  }
+  100% {
+    background-color: #f0f0f0;
+  }
+}

--- a/src/Components/RecommendationsPage/AIRecs/AIRecs.js
+++ b/src/Components/RecommendationsPage/AIRecs/AIRecs.js
@@ -1,0 +1,104 @@
+import React, { useState, useEffect, useRef } from 'react';
+import './AIRecs.css'
+import BrowserHeader from '../../ReusableComponents/BrowserHeader/BrowserHeader';
+import { Collapse, Box } from '@mui/material';
+import Button from '../../ReusableComponents/Button/Button';
+
+const AIRecs = ({handleRecSubmit, data}) => {
+  const [loading, setLoading] = useState(false);
+  const [received, setReceived] = useState(true);
+  const [requested, setRequested] = useState(true);
+  const [elapsedTime, setElapsedTime] = useState(0);
+  const intervalRef = useRef();
+
+  useEffect(() => {
+    if (loading) {
+      intervalRef.current = setInterval(() => {
+        setElapsedTime(prevTime => prevTime + 1);
+      }, 1000);
+    } else {
+      clearInterval(intervalRef.current);
+    }
+
+    return () => clearInterval(intervalRef.current);
+  }, [loading]);
+
+  const handleRequestButtonClick = () => {
+    setRequested(true);
+    setLoading(true);
+    handleRecSubmit();
+  };
+
+  const handleRefreshButtonClick = () => {
+    // clear to just allow them to click the button again - mostly designed to prevent too many requests
+    setReceived(false);
+    setRequested(false);
+  };
+
+  return (
+    <section className="ai-recs-section">
+      <BrowserHeader text="Request Personalized Game Recommendations"/>
+      <section className={`ai-recs-panel recommend-me-panel card ${requested ? 'panel-collapsed' : ''}`}>
+        <div className="ai-recs-number-wrapper">
+          <p className="ai-recs-header-number">1</p>
+        </div>
+        <Collapse in={!requested} timeout="auto">
+          <div className={`ai-recs-body ${requested ? 'hidden' : ''}`}>
+            <div className="ai-body-text">
+              <h4 className="ai-recs-header">Request Your Recommendations</h4>
+              <p className="ai-recs-text">We'll use your existing game collection to build a personalized recommendations list informed by what you're already drawn to in games and what we think you might enjoy.</p>
+            </div>
+            <Button text="Go" className="ai-submit" onClick={() => setLoading(true)} />
+          </div>
+        </Collapse>
+        <Collapse in={requested} timeout="auto">
+        <h4 className="ai-recs-header collapsed-header">Request</h4>
+        </Collapse>
+      </section>
+      <section className={`ai-recs-panel process-panel card ${!loading ? 'panel-collapsed' : ''}`}>
+        <div className="ai-recs-number-wrapper">
+          <p className="ai-recs-header-number">2</p>
+        </div>
+        <Collapse in={loading} timeout="auto">
+          <div className={`ai-recs-body process-body ${!loading ? 'hidden' : ''}`}>
+            <div className="ai-body-text">
+              <h4 className="ai-recs-header">Processing</h4>
+              <p className="ai-recs-text">Hold onto your ass while we crunch this data. If it takes longer than anticipated someone will be fired.</p>
+            </div>
+            <div className="time-wrapper">
+              <Box className="time-box">
+                <p className="timer-label">Estimated Wait: 10s</p>
+              </Box>
+              <Box className="time-box pulse">
+                <p className="timer-label">Actual: {elapsedTime}s</p>
+              </Box>
+            </div>
+          </div>
+        </Collapse>
+        <Collapse in={!loading} timeout="auto">
+          <h4 className="ai-recs-header collapsed-header">Processing</h4>
+        </Collapse>
+      </section>
+      <section className={`ai-recs-panel results-panel card ${!received ? 'panel-collapsed' : ''}`}>
+        <div className="ai-recs-number-wrapper">
+          <p className="ai-recs-header-number">3</p>
+        </div>
+        <Collapse in={received} timeout="auto">
+          <div className={`ai-recs-body results-body ${!received ? 'hidden' : ''}`}>
+            <div className="ai-body-text">
+              <h4 className="ai-recs-header">Recommendation Results</h4>
+              <p className="ai-recs-text">A team of scientists has been working day and night to create your recommendations. We think you're going to like the results - go take a look.</p>
+            </div>
+            <Button text="Again" className="ai-submit" onClick={() => setLoading(true)} />
+          </div>
+        </Collapse>
+        <Collapse in={!received} timeout="auto">
+          <h4 className="ai-recs-header collapsed-header">Results</h4>
+        </Collapse>
+      </section>
+    </section>
+
+  )
+}
+
+export default AIRecs;

--- a/src/Components/RecommendationsPage/RecOutput/RecOutput.js
+++ b/src/Components/RecommendationsPage/RecOutput/RecOutput.js
@@ -1,0 +1,39 @@
+import './RecOutput.css'
+import BrowserHeader from '../../ReusableComponents/BrowserHeader/BrowserHeader'
+import UserGame from '../../Profile/UserGame/UserGame';
+
+const RecOutput = (recommendations) => {
+  const mapRecs = () => {
+    if (recommendations) {
+      return recommendations.map(game => {
+        return (
+          <UserGame
+            key={game.id}
+            {...game}
+          />
+        );
+      });
+    }
+  }
+
+
+  if (!recommendations) return (
+    <>
+      <BrowserHeader text="Your Recommendations" />
+      <p className="no-recs">You don't have any recommendations yet. Request some!</p>
+    </>
+  )
+
+  return (
+    <div className="games-collection">
+      <BrowserHeader text="Game Collection" nomargin="true" />
+      <div className="games-grid">
+        {/* mapRecs() */}
+        <p>Recs go here</p>
+      </div>
+    </div>
+
+  )
+}
+
+export default RecOutput;

--- a/src/Components/RecommendationsPage/RecommendationsPage.css
+++ b/src/Components/RecommendationsPage/RecommendationsPage.css
@@ -1,0 +1,3 @@
+.recs-page {
+  grid-template-columns: 1.2fr 1fr;
+}

--- a/src/Components/RecommendationsPage/RecommendationsPage.js
+++ b/src/Components/RecommendationsPage/RecommendationsPage.js
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import './RecommendationsPage.css'
+import { useQuery, useMutation } from '@apollo/client';
+// import { requestRecommendationMutation } from '../../../queries';
+import { getUserGames } from '../../queries/index';
+import Header from '../ReusableComponents/Header/Header';
+import AIRecs from './AIRecs/AIRecs';
+import RecOutput from './RecOutput/RecOutput';
+
+const RecommendationsPage = ({ logoutUser, selectedUser }) => {
+  const [received, setReceived] = useState(false);
+  const { loading, error, data } = useQuery(getUserGames, { variables: { id: selectedUser } });
+
+  
+  const handleRecSubmit = () => {
+    const userGamesArray = data.user.ownedGames;
+
+    // do mutation and pass in array
+    // pass data to RecOutput
+    // pass loading, data to AIRecs to progress through form collapsibles
+    // when data is received setReceived to true so that the results bit will pop up.
+  };
+
+  return (
+    <>
+      <Header logoutUser={logoutUser}/>
+      <section className="profile-page recs-page">
+        <AIRecs handleRecSubmit={handleRecSubmit} received={received}/>
+        <RecOutput />
+      </section>
+    </>
+  )
+}
+
+export default RecommendationsPage;

--- a/src/Components/ReusableComponents/BrowserHeader/BrowserHeader.css
+++ b/src/Components/ReusableComponents/BrowserHeader/BrowserHeader.css
@@ -5,7 +5,7 @@
   color: #ffffff;
   color: rgb(255, 255, 255);
   opacity: 0.9;
-  margin: 3rem 0 0rem 0;
+  margin: 0;
   padding-left: 0.2rem;
   padding-bottom: 0.5rem;
   border-bottom: 0.1px solid rgba(255, 160, 228, 1);

--- a/src/Components/ReusableComponents/Button/Button.css
+++ b/src/Components/ReusableComponents/Button/Button.css
@@ -30,6 +30,14 @@
   height: 3.5rem;
 }
 
+.ai-submit {
+  margin-left: 2rem !important;
+  width: 8rem !important;
+  height: 5rem !important;
+  background-color: rgb(93, 83, 230, 0.8) !important;
+  border-radius: 12px !important;
+}
+
 @keyframes glowing {
   0% {
     box-shadow: 0 0 5px #fefefe;

--- a/src/Components/ReusableComponents/Header/Header.js
+++ b/src/Components/ReusableComponents/Header/Header.js
@@ -20,6 +20,10 @@ const Header = ({ logoutUser }) => {
       }
     },
     {
+      label: 'Recommendations',
+      link: '/recommendations',
+    },
+    {
       label: 'Logout',
       link: '/',
       handler: () => {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import App from './Components/App/App.js';
 import reportWebVitals from './reportWebVitals';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { ApolloClient, InMemoryCache, ApolloProvider, createHttpLink } from '@apollo/client';
+import { persistCache } from 'apollo3-cache-persist';
 
 const link = createHttpLink({
   uri: 'https://game-night-backend-172o.onrender.com/graphql',
@@ -13,6 +14,11 @@ const link = createHttpLink({
 const client = new ApolloClient({
   cache: new InMemoryCache(),
   link
+});
+
+persistCache({
+  cache: client.cache,
+  storage: window.localStorage,
 });
 
 const root = ReactDOM.createRoot(document.getElementById('root'));


### PR DESCRIPTION
# Checklist:

## Type of change:

   - [x] New feature
   - [] Bug Fix
   - [x] Refactor

## Description of Changes:

- Adds a route, view, and components for the recommendations page in order to harbor the goblin boys' AI recommendations data.
- Creates some tentative logic for a) cycling through the panels as the request progresses, b) getting together the array of the user's games to post over the info necessary for the request, c) mapping those games on the right-hand side of the page into userGames components, the same ones used on the profile page.
- Writes the logged in user and logged in state to the local cache so that people don't get logged out when refreshing or navigating manually etc. Now they only get logged out if they specifically log out or if it's been a long time.

## Requested feedback: 
    
It's open season on this.

## Check the correct boxes:

   - [x] This broke nothing
   - [] This broke some stuff
   - [] This broke everything

## Testing Changes:

   - [x] No Tests have been changed
   - [] Some Tests have been changed
   - [] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:
   - [] All Tests are Passing (same issues)
   - [] My code has no unused/commented out code
   - [x] I have reviewed my code
   - [x] I have commented on my code, particularly in hard-to-understand areas - extensively
   - [] I have fully tested my code
   - [x] I have added one or more people as "Reviewers" to review & merge
