### PR TITLE
Recommendations Page Data + Logic Fixes

### DIFF
--- a/src/Components/RecommendationsPage/AIRecs/AIRecs.js
+++ b/src/Components/RecommendationsPage/AIRecs/AIRecs.js
@@ -4,10 +4,8 @@ import BrowserHeader from '../../ReusableComponents/BrowserHeader/BrowserHeader'
 import { Collapse, Box } from '@mui/material';
 import Button from '../../ReusableComponents/Button/Button';
 
-const AIRecs = ({handleRecSubmit, data}) => {
-  const [loading, setLoading] = useState(false);
-  const [received, setReceived] = useState(true);
-  const [requested, setRequested] = useState(true);
+const AIRecs = ({handleRecSubmit, received, loading, setDataReceived}) => {
+  const [requested, setRequested] = useState(false);
   const [elapsedTime, setElapsedTime] = useState(0);
   const intervalRef = useRef();
 
@@ -25,14 +23,12 @@ const AIRecs = ({handleRecSubmit, data}) => {
 
   const handleRequestButtonClick = () => {
     setRequested(true);
-    setLoading(true);
     handleRecSubmit();
   };
 
   const handleRefreshButtonClick = () => {
-    // clear to just allow them to click the button again - mostly designed to prevent too many requests
-    setReceived(false);
     setRequested(false);
+    setDataReceived(false);
   };
 
   return (
@@ -48,7 +44,7 @@ const AIRecs = ({handleRecSubmit, data}) => {
               <h4 className="ai-recs-header">Request Your Recommendations</h4>
               <p className="ai-recs-text">We'll use your existing game collection to build a personalized recommendations list informed by what you're already drawn to in games and what we think you might enjoy.</p>
             </div>
-            <Button text="Go" className="ai-submit" onClick={() => setLoading(true)} />
+            <Button text="Go" className="ai-submit" onClick={() => handleRequestButtonClick()} />
           </div>
         </Collapse>
         <Collapse in={requested} timeout="auto">
@@ -89,7 +85,7 @@ const AIRecs = ({handleRecSubmit, data}) => {
               <h4 className="ai-recs-header">Recommendation Results</h4>
               <p className="ai-recs-text">A team of scientists has been working day and night to create your recommendations. We think you're going to like the results - go take a look.</p>
             </div>
-            <Button text="Again" className="ai-submit" onClick={() => setLoading(true)} />
+            <Button text="Again" className="ai-submit" onClick={() => handleRefreshButtonClick()}/>
           </div>
         </Collapse>
         <Collapse in={!received} timeout="auto">

--- a/src/Components/RecommendationsPage/RecOutput/RecOutput.css
+++ b/src/Components/RecommendationsPage/RecOutput/RecOutput.css
@@ -1,0 +1,20 @@
+.no-recs {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  height: 80vh;
+  width: 80%;
+  font-size: 2.5rem;
+  color: rgba(255, 255, 255, 1);
+  font-weight: 300;
+  font-family: 'Avenir Next', sans-serif;
+  text-align: center;
+}
+
+.no-recs-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/Components/RecommendationsPage/RecOutput/RecOutput.js
+++ b/src/Components/RecommendationsPage/RecOutput/RecOutput.js
@@ -2,10 +2,10 @@ import './RecOutput.css'
 import BrowserHeader from '../../ReusableComponents/BrowserHeader/BrowserHeader'
 import UserGame from '../../Profile/UserGame/UserGame';
 
-const RecOutput = (recommendations) => {
+const RecOutput = ({ recommendations }) => { // Destructure the recommendations prop directly
   const mapRecs = () => {
-    if (recommendations) {
-      return recommendations.map(game => {
+    if (recommendations && recommendations.user) {
+      return recommendations.user.recommendedGames.map(game => {
         return (
           <UserGame
             key={game.id}
@@ -16,19 +16,20 @@ const RecOutput = (recommendations) => {
     }
   }
 
-
-  if (!recommendations) return (
-    <>
-      <BrowserHeader text="Your Recommendations" />
-      <p className="no-recs">You don't have any recommendations yet. Request some!</p>
-    </>
+  if (!recommendations || !recommendations.user || !recommendations.user.recommendedGames.length) return (
+    <div className="games-collection">
+      <BrowserHeader text="Recommendations for You" />
+      <div className="no-recs-wrapper">
+        <h5 className="no-recs">You don't have any recommendations yet. Try asking for some!</h5>
+      </div>
+    </div>
   )
 
   return (
     <div className="games-collection">
-      <BrowserHeader text="Game Collection" nomargin="true" />
+      <BrowserHeader text="Recommendations for You" nomargin="true" />
       <div className="games-grid">
-        {/* mapRecs() */}
+          {mapRecs()}
         <p>Recs go here</p>
       </div>
     </div>

--- a/src/Components/RecommendationsPage/RecommendationsPage.js
+++ b/src/Components/RecommendationsPage/RecommendationsPage.js
@@ -1,32 +1,36 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './RecommendationsPage.css'
-import { useQuery, useMutation } from '@apollo/client';
-// import { requestRecommendationMutation } from '../../../queries';
-import { getUserGames } from '../../queries/index';
+import { useLazyQuery } from '@apollo/client';
+import { getUserRecommendations } from '../../queries/index';
 import Header from '../ReusableComponents/Header/Header';
 import AIRecs from './AIRecs/AIRecs';
 import RecOutput from './RecOutput/RecOutput';
 
 const RecommendationsPage = ({ logoutUser, selectedUser }) => {
-  const [received, setReceived] = useState(false);
-  const { loading, error, data } = useQuery(getUserGames, { variables: { id: selectedUser } });
+  const [dataReceived, setDataReceived] = useState(false);
+  const [getUserRecs, { loading, data, error }] = useLazyQuery(getUserRecommendations, {
+    onCompleted: () => {
+      setDataReceived(true);
+    }
+  });
 
-  
-  const handleRecSubmit = () => {
-    const userGamesArray = data.user.ownedGames;
+  const handleRecSubmit = async () => {
+      getUserRecs({ variables: { id: selectedUser } });
+  }
 
-    // do mutation and pass in array
-    // pass data to RecOutput
-    // pass loading, data to AIRecs to progress through form collapsibles
-    // when data is received setReceived to true so that the results bit will pop up.
-  };
+  useEffect(() => {
+    if (dataReceived) {
+      console.log(data)
+    }
+  }, [dataReceived])
+
 
   return (
     <>
       <Header logoutUser={logoutUser}/>
       <section className="profile-page recs-page">
-        <AIRecs handleRecSubmit={handleRecSubmit} received={received}/>
-        <RecOutput />
+        <AIRecs handleRecSubmit={handleRecSubmit} received={dataReceived} loading={loading} setDataReceived={setDataReceived}/>
+        <RecOutput recommendations={data} />
       </section>
     </>
   )

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -250,3 +250,22 @@ export const cancelEvent = gql`
     }
   }
 `;
+
+export const getUserRecommendations = gql`
+query getUser($id: ID!) {
+	user(id: $id) {
+    recommendedGames {
+      id
+      name
+      minPlayers
+      maxPlayers
+      minPlaytime
+      maxPlaytime
+      description
+      imageUrl
+      averageUserRating
+      averageStrategyComplexity
+    }
+  }
+}
+`;


### PR DESCRIPTION
# Checklist:

## Type of change:

   - [x] New feature
   - [] Bug Fix
   - [x] Refactor

## Description of Changes:

- Hooks up the recommendations view to the backend's new API query.
- Maps over the recommendations data to produce userGames cards for them in line with the profile page.
- Fixes the logic so that the panels correctly progress in order as the query is being requested/fulfilled and then resets when they hit the refresh button.

## Requested feedback: 

- Now that I'm typing this I realize that this needs some error handling. I think maybe adding another conditional return saying "recommendations query failed" might work vs. redirecting them entirely.
- Needs testing!
- Happy to change in line with Adriane's changes to the colors. 

## Check the correct boxes:

   - [x] This broke nothing
   - [] This broke some stuff
   - [] This broke everything

## Testing Changes:

   - [x] No Tests have been changed
   - [] Some Tests have been changed
   - [] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:
   - [x] All Tests are Passing
   - [x] My code has no unused/commented out code
   - [x] I have reviewed my code
   - [x] I have commented on my code, particularly in hard-to-understand areas
   - [x] I have fully tested my code
   - [x] I have added one or more people as "Reviewers" to review & merge
